### PR TITLE
feat(quiz): Quiz engine for Line Cooks — closes #8

### DIFF
--- a/package.json
+++ b/package.json
@@ -9,7 +9,9 @@
     "lint": "next lint",
     "db:push": "drizzle-kit push",
     "db:studio": "drizzle-kit studio",
-    "seed": "tsx src/scripts/seed-from-csv.ts"
+    "seed": "tsx src/scripts/seed-from-csv.ts",
+    "seed:questions": "tsx src/scripts/seed-questions.ts",
+    "seed:all": "npm run seed && npm run seed:questions"
   },
   "dependencies": {
     "@ai-sdk/anthropic": "^1.2.0",

--- a/src/app/(linecook)/dashboard/[id]/RecipeActions.tsx
+++ b/src/app/(linecook)/dashboard/[id]/RecipeActions.tsx
@@ -2,12 +2,32 @@
 
 import { useState } from 'react';
 import { ChatDrawer } from '@/components/ChatDrawer';
+import { QuizDrawer } from '@/components/QuizDrawer';
 
-export default function RecipeActions({ recipeId }: { recipeId: string }) {
+export default function RecipeActions({
+  recipeId,
+  recipeTitle,
+}: {
+  recipeId: string;
+  recipeTitle: string;
+}) {
   const [chatOpen, setChatOpen] = useState(false);
+  const [quizOpen, setQuizOpen] = useState(false);
 
   return (
     <>
+      {/* Quiz FAB — sits above chat FAB */}
+      <button
+        onClick={() => setQuizOpen(true)}
+        aria-label="Quiz yourself on this recipe"
+        className="fixed bottom-[172px] right-6 w-14 h-14 bg-[#001b3c] rounded-full shadow-xl flex items-center justify-center text-white hover:bg-[#526a8d] active:bg-[#3d5270] transition-colors z-40"
+      >
+        <span className="material-symbols-outlined text-2xl" style={{ fontVariationSettings: "'FILL' 1" }}>
+          quiz
+        </span>
+      </button>
+
+      {/* Chat FAB */}
       <button
         onClick={() => setChatOpen(true)}
         aria-label="Ask Pellito about this recipe"
@@ -33,6 +53,13 @@ export default function RecipeActions({ recipeId }: { recipeId: string }) {
         isOpen={chatOpen}
         onClose={() => setChatOpen(false)}
         recipeId={recipeId}
+      />
+
+      <QuizDrawer
+        isOpen={quizOpen}
+        onClose={() => setQuizOpen(false)}
+        recipeId={recipeId}
+        recipeTitle={recipeTitle}
       />
     </>
   );

--- a/src/app/(linecook)/dashboard/[id]/page.tsx
+++ b/src/app/(linecook)/dashboard/[id]/page.tsx
@@ -205,8 +205,8 @@ export default async function RecipeDetailPage({
         ))}
       </nav>
 
-      {/* Pellito Chat FAB + Drawer (client) */}
-      <RecipeActions recipeId={recipe.id} />
+      {/* FABs + Drawers (client) */}
+      <RecipeActions recipeId={recipe.id} recipeTitle={recipe.title} />
     </div>
   );
 }

--- a/src/app/api/quiz/[recipeId]/route.ts
+++ b/src/app/api/quiz/[recipeId]/route.ts
@@ -1,0 +1,38 @@
+import { NextRequest, NextResponse } from 'next/server';
+import { cookies } from 'next/headers';
+import { verifySession, COOKIE_NAME } from '@/lib/session';
+import { getQuestionsForRecipe, insertQuestions } from '@/db/quiz';
+import { getRecipe } from '@/db/recipes';
+import { generateQuestions } from '@/lib/quiz-generator';
+
+function pickRandom<T>(arr: T[], n: number): T[] {
+  return [...arr].sort(() => Math.random() - 0.5).slice(0, n);
+}
+
+export async function GET(
+  _req: NextRequest,
+  { params }: { params: Promise<{ recipeId: string }> },
+) {
+  const cookieStore = await cookies();
+  const sessionCookie = cookieStore.get(COOKIE_NAME);
+  if (!sessionCookie) return NextResponse.json({ error: 'Unauthorized' }, { status: 401 });
+  const role = await verifySession(sessionCookie.value);
+  if (!role) return NextResponse.json({ error: 'Unauthorized' }, { status: 401 });
+
+  const { recipeId } = await params;
+  let questions = await getQuestionsForRecipe(recipeId);
+
+  // Lazy generation if questions were never seeded for this recipe
+  if (!questions.length) {
+    const recipe = await getRecipe(recipeId);
+    if (!recipe) return NextResponse.json({ error: 'Recipe not found' }, { status: 404 });
+    const generated = generateQuestions(recipe);
+    await insertQuestions(recipeId, generated);
+    questions = await getQuestionsForRecipe(recipeId);
+  }
+
+  const easy = pickRandom(questions.filter(q => q.difficulty === 'easy'), 5);
+  const hard = pickRandom(questions.filter(q => q.difficulty === 'hard'), 3);
+
+  return NextResponse.json({ easy, hard });
+}

--- a/src/app/api/quiz/answer/route.ts
+++ b/src/app/api/quiz/answer/route.ts
@@ -1,0 +1,27 @@
+import { NextRequest, NextResponse } from 'next/server';
+import { cookies } from 'next/headers';
+import { verifySession, COOKIE_NAME } from '@/lib/session';
+import { recordAnswer } from '@/db/quiz';
+
+export async function POST(req: NextRequest) {
+  const cookieStore = await cookies();
+  const sessionCookie = cookieStore.get(COOKIE_NAME);
+  if (!sessionCookie) return NextResponse.json({ error: 'Unauthorized' }, { status: 401 });
+  const role = await verifySession(sessionCookie.value);
+  if (!role) return NextResponse.json({ error: 'Unauthorized' }, { status: 401 });
+
+  let body: { recipe_id: string; question_id: string; correct: boolean; language?: string };
+  try {
+    body = await req.json();
+  } catch {
+    return NextResponse.json({ error: 'Invalid JSON' }, { status: 400 });
+  }
+
+  const { recipe_id, question_id, correct, language } = body;
+  if (!recipe_id || !question_id || typeof correct !== 'boolean') {
+    return NextResponse.json({ error: 'Missing required fields' }, { status: 400 });
+  }
+
+  await recordAnswer({ recipe_id, question_id, correct, role, language });
+  return NextResponse.json({ ok: true });
+}

--- a/src/components/QuizDrawer.tsx
+++ b/src/components/QuizDrawer.tsx
@@ -1,0 +1,335 @@
+'use client';
+
+import { useEffect, useState } from 'react';
+
+interface QuizQuestion {
+  id: string;
+  recipe_id: string;
+  difficulty: 'easy' | 'hard';
+  question_text: string;
+  choices: string[];
+  correct_index: number;
+}
+
+interface QuizDrawerProps {
+  isOpen: boolean;
+  onClose: () => void;
+  recipeId: string;
+  recipeTitle: string;
+}
+
+type Phase = 'idle' | 'loading' | 'easy' | 'easy-result' | 'hard' | 'hard-result';
+
+interface Feedback {
+  selected: number;
+  isCorrect: boolean;
+}
+
+const CHOICE_LABELS = ['A', 'B', 'C', 'D'];
+
+export function QuizDrawer({ isOpen, onClose, recipeId, recipeTitle }: QuizDrawerProps) {
+  const [phase, setPhase] = useState<Phase>('idle');
+  const [easyQs, setEasyQs] = useState<QuizQuestion[]>([]);
+  const [hardQs, setHardQs] = useState<QuizQuestion[]>([]);
+  const [currentIdx, setCurrentIdx] = useState(0);
+  const [easyScore, setEasyScore] = useState(0);
+  const [hardScore, setHardScore] = useState(0);
+  const [feedback, setFeedback] = useState<Feedback | null>(null);
+  const [error, setError] = useState<string | null>(null);
+
+  useEffect(() => {
+    const handler = (e: KeyboardEvent) => { if (e.key === 'Escape' && isOpen) onClose(); };
+    window.addEventListener('keydown', handler);
+    return () => window.removeEventListener('keydown', handler);
+  }, [isOpen, onClose]);
+
+  // Reset state when drawer closes
+  useEffect(() => {
+    if (!isOpen) {
+      setPhase('idle');
+      setEasyQs([]);
+      setHardQs([]);
+      setCurrentIdx(0);
+      setEasyScore(0);
+      setHardScore(0);
+      setFeedback(null);
+      setError(null);
+    }
+  }, [isOpen]);
+
+  async function startQuiz() {
+    setPhase('loading');
+    setError(null);
+    try {
+      const res = await fetch(`/api/quiz/${recipeId}`);
+      if (!res.ok) throw new Error(`HTTP ${res.status}`);
+      const data = await res.json();
+      if (!data.easy?.length) throw new Error('No questions available for this recipe.');
+      setEasyQs(data.easy);
+      setHardQs(data.hard ?? []);
+      setCurrentIdx(0);
+      setEasyScore(0);
+      setHardScore(0);
+      setPhase('easy');
+    } catch (err) {
+      setError(err instanceof Error ? err.message : 'Failed to load quiz. Try again.');
+      setPhase('idle');
+    }
+  }
+
+  async function handleAnswer(selectedIdx: number) {
+    if (feedback) return;
+    const q = phase === 'easy' ? easyQs[currentIdx] : hardQs[currentIdx];
+    const isCorrect = selectedIdx === q.correct_index;
+    setFeedback({ selected: selectedIdx, isCorrect });
+    if (phase === 'easy' && isCorrect) setEasyScore(s => s + 1);
+    if (phase === 'hard' && isCorrect) setHardScore(s => s + 1);
+
+    // Fire-and-forget metric recording
+    fetch('/api/quiz/answer', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ recipe_id: recipeId, question_id: q.id, correct: isCorrect }),
+    }).catch(() => {});
+  }
+
+  function advance() {
+    if (!feedback) return;
+    const qs = phase === 'easy' ? easyQs : hardQs;
+    const limit = phase === 'easy' ? 5 : 3;
+    const next = currentIdx + 1;
+    setFeedback(null);
+    if (next < Math.min(qs.length, limit)) {
+      setCurrentIdx(next);
+    } else {
+      setPhase(phase === 'easy' ? 'easy-result' : 'hard-result');
+    }
+  }
+
+  function startHard() {
+    setCurrentIdx(0);
+    setHardScore(0);
+    setFeedback(null);
+    setPhase('hard');
+  }
+
+  const activeQs = (phase === 'easy' || phase === 'hard') ? (phase === 'easy' ? easyQs : hardQs) : [];
+  const totalQs = phase === 'easy' ? Math.min(easyQs.length, 5) : Math.min(hardQs.length, 3);
+  const currentQ = activeQs[currentIdx];
+  const easyTotal = Math.min(easyQs.length, 5);
+  const hardTotal = Math.min(hardQs.length, 3);
+
+  return (
+    <>
+      {/* Backdrop */}
+      <div
+        onClick={onClose}
+        aria-hidden="true"
+        className={`fixed inset-0 bg-black z-40 transition-opacity duration-300 ${
+          isOpen ? 'opacity-40 pointer-events-auto' : 'opacity-0 pointer-events-none'
+        }`}
+      />
+
+      {/* Drawer */}
+      <div
+        role="dialog"
+        aria-modal="true"
+        aria-label="Recipe quiz"
+        className={`fixed bottom-0 left-0 right-0 z-50 flex flex-col bg-[#f9f9ff] transform transition-transform duration-300 ease-out ${
+          isOpen ? 'translate-y-0' : 'translate-y-full'
+        }`}
+        style={{ height: '82vh', maxHeight: '700px' }}
+      >
+        {/* Header */}
+        <div className="flex items-center justify-between px-4 py-3 bg-[#001b3c] text-white flex-shrink-0">
+          <div className="flex items-center gap-2">
+            <span className="material-symbols-outlined text-xl" style={{ fontVariationSettings: "'FILL' 1" }}>quiz</span>
+            <span className="font-grotesk font-bold text-sm tracking-widest uppercase truncate max-w-[220px]">
+              {recipeTitle}
+            </span>
+          </div>
+          <button onClick={onClose} aria-label="Close quiz" className="text-white/70 hover:text-white text-xl leading-none ml-2 flex-shrink-0">
+            ✕
+          </button>
+        </div>
+
+        {/* Body */}
+        <div className="flex-1 overflow-y-auto px-4 py-6">
+
+          {/* IDLE */}
+          {phase === 'idle' && (
+            <div className="flex flex-col items-center gap-6 mt-6 text-center">
+              <span className="material-symbols-outlined text-7xl text-[#526a8d]" style={{ fontVariationSettings: "'FILL' 1" }}>quiz</span>
+              <div>
+                <p className="font-grotesk font-black uppercase text-[#001b3c] text-xl tracking-tight">Test yourself</p>
+                <p className="font-sans text-[#74777f] text-sm mt-2 max-w-xs">
+                  5 multiple-choice questions on this recipe. Easy questions test recall — ingredients, steps, plateware.
+                </p>
+              </div>
+              {error && <p className="text-red-600 text-sm font-sans">{error}</p>}
+              <button
+                onClick={startQuiz}
+                className="bg-[#001b3c] text-white font-grotesk font-bold uppercase tracking-wide px-10 py-3 hover:bg-[#526a8d] transition-colors"
+              >
+                Start Quiz
+              </button>
+            </div>
+          )}
+
+          {/* LOADING */}
+          {phase === 'loading' && (
+            <div className="flex items-center justify-center h-40">
+              <p className="font-grotesk text-[#526a8d] animate-pulse tracking-wide">Loading questions…</p>
+            </div>
+          )}
+
+          {/* EASY / HARD — question */}
+          {(phase === 'easy' || phase === 'hard') && currentQ && (
+            <div className="flex flex-col gap-5 max-w-lg mx-auto">
+              {/* Progress bar */}
+              <div className="flex items-center justify-between mb-1">
+                <span className="font-grotesk font-bold uppercase text-xs text-[#526a8d] tracking-widest">
+                  {phase === 'easy' ? 'Easy' : 'Hard'} · {currentIdx + 1}/{totalQs}
+                </span>
+                <div className="flex gap-1">
+                  {Array.from({ length: totalQs }).map((_, i) => (
+                    <div
+                      key={i}
+                      className={`h-1.5 w-6 rounded-sm transition-colors ${
+                        i < currentIdx ? 'bg-[#526a8d]' : i === currentIdx ? 'bg-[#001b3c]' : 'bg-[#74777f]/25'
+                      }`}
+                    />
+                  ))}
+                </div>
+              </div>
+
+              {/* Question */}
+              <div className="bg-[#001b3c] text-white px-5 py-4 border-l-4 border-[#526a8d]">
+                <p className="font-sans text-base leading-relaxed whitespace-pre-wrap">{currentQ.question_text}</p>
+              </div>
+
+              {/* Choices */}
+              <div className="flex flex-col gap-2">
+                {currentQ.choices.map((choice, i) => {
+                  const isCorrect = i === currentQ.correct_index;
+                  const isSelected = feedback?.selected === i;
+                  let cls =
+                    'w-full border-2 border-[#001b3c] bg-white px-4 py-3 text-left font-sans text-[#001b3c] text-sm leading-snug flex items-start gap-3 hover:border-[#526a8d] hover:bg-[#f0f3ff] transition-colors cursor-pointer';
+
+                  if (feedback) {
+                    if (isCorrect) {
+                      cls = 'w-full border-2 border-green-600 bg-green-50 px-4 py-3 text-left font-sans text-green-800 text-sm leading-snug flex items-start gap-3 cursor-default';
+                    } else if (isSelected) {
+                      cls = 'w-full border-2 border-red-500 bg-red-50 px-4 py-3 text-left font-sans text-red-700 text-sm leading-snug flex items-start gap-3 cursor-default';
+                    } else {
+                      cls = 'w-full border-2 border-[#74777f]/30 bg-white px-4 py-3 text-left font-sans text-[#74777f] text-sm leading-snug flex items-start gap-3 cursor-default opacity-50';
+                    }
+                  }
+
+                  return (
+                    <button key={i} className={cls} onClick={() => handleAnswer(i)} disabled={!!feedback}>
+                      <span className="font-grotesk font-bold text-xs flex-shrink-0 mt-0.5 w-4">
+                        {CHOICE_LABELS[i]}.
+                      </span>
+                      <span>{choice}</span>
+                    </button>
+                  );
+                })}
+              </div>
+
+              {/* Feedback + Next */}
+              {feedback && (
+                <div className="flex flex-col gap-3">
+                  <div className={`flex items-start gap-2 px-4 py-3 ${feedback.isCorrect ? 'bg-green-100 text-green-800' : 'bg-red-50 text-red-700'}`}>
+                    <span className="material-symbols-outlined text-xl flex-shrink-0 mt-0.5">
+                      {feedback.isCorrect ? 'check_circle' : 'cancel'}
+                    </span>
+                    <span className="font-grotesk font-bold text-sm uppercase tracking-wide">
+                      {feedback.isCorrect
+                        ? 'Correct!'
+                        : `Incorrect — answer: ${currentQ.choices[currentQ.correct_index]}`}
+                    </span>
+                  </div>
+                  <div className="flex justify-end">
+                    <button
+                      onClick={advance}
+                      className="bg-[#526a8d] text-white font-grotesk font-bold uppercase tracking-wide px-6 py-2.5 text-sm hover:bg-[#3d5270] transition-colors"
+                    >
+                      {currentIdx + 1 < totalQs ? 'Next →' : 'Results →'}
+                    </button>
+                  </div>
+                </div>
+              )}
+            </div>
+          )}
+
+          {/* EASY RESULT */}
+          {phase === 'easy-result' && (
+            <div className="flex flex-col items-center gap-6 mt-4 text-center max-w-sm mx-auto">
+              <span className="material-symbols-outlined text-7xl text-[#526a8d]" style={{ fontVariationSettings: "'FILL' 1" }}>
+                {easyScore === easyTotal ? 'emoji_events' : easyScore >= Math.ceil(easyTotal / 2) ? 'thumb_up' : 'sentiment_neutral'}
+              </span>
+              <div>
+                <p className="font-grotesk font-black uppercase text-[#001b3c] text-3xl tracking-tight">
+                  {easyScore} / {easyTotal}
+                </p>
+                <p className="font-sans text-[#74777f] text-sm mt-1">
+                  {easyScore === easyTotal
+                    ? 'Perfect! You know this recipe cold.'
+                    : easyScore >= Math.ceil(easyTotal / 2)
+                    ? 'Good work — keep it up!'
+                    : 'Keep studying this one!'}
+                </p>
+              </div>
+
+              {hardQs.length > 0 && (
+                <div className="w-full flex flex-col gap-3 mt-2">
+                  <p className="font-grotesk font-bold uppercase text-xs text-[#526a8d] tracking-widest">Want a challenge?</p>
+                  <button
+                    onClick={startHard}
+                    className="w-full bg-[#001b3c] text-white font-grotesk font-bold uppercase tracking-wide px-6 py-3 hover:bg-[#526a8d] transition-colors"
+                  >
+                    Try 3 Harder Questions →
+                  </button>
+                </div>
+              )}
+
+              <button onClick={onClose} className="text-[#526a8d] font-grotesk font-bold uppercase text-xs tracking-widest underline mt-1">
+                Done
+              </button>
+            </div>
+          )}
+
+          {/* HARD RESULT */}
+          {phase === 'hard-result' && (
+            <div className="flex flex-col items-center gap-6 mt-4 text-center max-w-sm mx-auto">
+              <span className="material-symbols-outlined text-7xl text-[#526a8d]" style={{ fontVariationSettings: "'FILL' 1" }}>
+                {hardScore === hardTotal ? 'emoji_events' : hardScore >= 2 ? 'thumb_up' : 'sentiment_neutral'}
+              </span>
+              <div>
+                <p className="font-grotesk font-black uppercase text-[#001b3c] text-3xl tracking-tight">
+                  {hardScore} / {hardTotal}
+                </p>
+                <p className="font-sans text-[#74777f] text-sm mt-1">Hard questions done!</p>
+              </div>
+
+              <div className="bg-white border-2 border-[#001b3c] px-6 py-4 w-full">
+                <p className="font-grotesk font-bold uppercase text-xs text-[#74777f] tracking-widest mb-1">Total score</p>
+                <p className="font-grotesk font-black text-[#001b3c] text-2xl">
+                  {easyScore + hardScore} / {easyTotal + hardTotal}
+                </p>
+              </div>
+
+              <button
+                onClick={onClose}
+                className="bg-[#001b3c] text-white font-grotesk font-bold uppercase tracking-wide px-10 py-3 hover:bg-[#526a8d] transition-colors"
+              >
+                Done
+              </button>
+            </div>
+          )}
+        </div>
+      </div>
+    </>
+  );
+}

--- a/src/db/quiz.ts
+++ b/src/db/quiz.ts
@@ -1,0 +1,39 @@
+import { eq } from 'drizzle-orm';
+import { db } from './index';
+import { quizQuestions, metrics } from './schema';
+
+export type QuizQuestionRow = typeof quizQuestions.$inferSelect;
+
+export async function getQuestionsForRecipe(recipeId: string): Promise<QuizQuestionRow[]> {
+  return db.select().from(quizQuestions).where(eq(quizQuestions.recipe_id, recipeId));
+}
+
+export async function insertQuestions(
+  recipeId: string,
+  questions: {
+    difficulty: 'easy' | 'hard';
+    question_text: string;
+    choices: string[];
+    correct_index: number;
+    source_field: string;
+  }[],
+): Promise<void> {
+  if (!questions.length) return;
+  await db.insert(quizQuestions).values(questions.map(q => ({ ...q, recipe_id: recipeId })));
+}
+
+export async function recordAnswer(data: {
+  recipe_id: string;
+  question_id: string;
+  correct: boolean;
+  role: string;
+  language?: string;
+}): Promise<void> {
+  await db.insert(metrics).values({
+    recipe_id: data.recipe_id,
+    question_id: data.question_id,
+    correct: data.correct,
+    role: data.role,
+    language: data.language ?? 'English',
+  });
+}

--- a/src/lib/quiz-generator.ts
+++ b/src/lib/quiz-generator.ts
@@ -1,0 +1,193 @@
+export interface GeneratedQuestion {
+  difficulty: 'easy' | 'hard';
+  question_text: string;
+  choices: string[];
+  correct_index: number;
+  source_field: string;
+}
+
+interface RecipeFields {
+  ingredients: string[];
+  plateware?: string | null;
+  cook_steps: string[];
+  plate_steps: string[];
+}
+
+const PLATEWARE_POOL = [
+  'round dinner plate', 'oval ceramic plate', 'square plate', 'coupe bowl',
+  'pasta bowl', 'soup bowl', 'cast iron skillet', 'wooden board',
+  'wide-rim bowl', 'shallow bowl', 'ceramic ramekin', 'slate tile',
+  'long rectangular plate', 'wicker basket', 'parchment-lined tray',
+];
+
+const FAKE_INGREDIENTS = [
+  'truffle oil', 'saffron threads', 'tahini', 'miso paste', 'harissa',
+  'anchovy paste', 'preserved lemon', 'sumac', "za'atar", 'pomegranate molasses',
+  'fish sauce', 'oyster sauce', 'galangal', 'lemongrass', 'coconut cream',
+  'tamarind paste', 'cardamom pods', 'fenugreek', 'dried hibiscus', 'mirin',
+  'ras el hanout', 'black sesame oil', 'nori flakes', 'bonito flakes', 'yuzu juice',
+];
+
+const FAKE_QUANTITIES = [
+  '1 oz', '2 oz', '3 oz', '4 oz', '6 oz', '8 oz', '1/2 cup', '1 cup',
+  '2 cups', '1 Tbsp', '2 Tbsp', '1/4 cup', '1 tsp', '2 tsp', '1 lb', '2 lb',
+  '1/2 lb', '1 each', '2 each', '3 each', '1/2 tsp', '3 Tbsp',
+];
+
+function shuffle<T>(arr: T[]): T[] {
+  const a = [...arr];
+  for (let i = a.length - 1; i > 0; i--) {
+    const j = Math.floor(Math.random() * (i + 1));
+    [a[i], a[j]] = [a[j], a[i]];
+  }
+  return a;
+}
+
+function pickN<T>(pool: T[], n: number, exclude: string[] = []): T[] {
+  const excLower = exclude.map(s => s.toLowerCase());
+  return shuffle(pool.filter(x => !excLower.includes(String(x).toLowerCase()))).slice(0, n);
+}
+
+function makeChoices(correct: string, distractors: string[]): { choices: string[]; correct_index: number } {
+  const all = shuffle([correct, ...distractors.slice(0, 3)]);
+  return { choices: all, correct_index: all.indexOf(correct) };
+}
+
+function trunc(s: string, max = 110): string {
+  return s.length > max ? s.slice(0, max).trimEnd() + '…' : s;
+}
+
+function parseIngredient(s: string): { qty: string; name: string } {
+  const m = s.match(/^([\d.\/]+(?:\s+(?:each|fl oz|oz|tsp|Tbsp|cup|lb|g|kg))?)\s+(.+)$/i);
+  return m ? { qty: m[1].trim(), name: m[2].trim() } : { qty: '', name: s };
+}
+
+function push(arr: GeneratedQuestion[], q: GeneratedQuestion | null) {
+  if (q) arr.push(q);
+}
+
+// ---------------------------------------------------------------------------
+// Easy generators
+// ---------------------------------------------------------------------------
+
+function qPlateware(recipe: RecipeFields): GeneratedQuestion | null {
+  if (!recipe.plateware) return null;
+  const correct = recipe.plateware;
+  const distractors = pickN(PLATEWARE_POOL, 3, [correct.toLowerCase()]);
+  if (distractors.length < 3) return null;
+  const { choices, correct_index } = makeChoices(correct, distractors);
+  return { difficulty: 'easy', question_text: 'What plateware is used for this dish?', choices, correct_index, source_field: 'plateware' };
+}
+
+function qIngredientIs(recipe: RecipeFields): GeneratedQuestion | null {
+  if (!recipe.ingredients.length) return null;
+  const parsed = recipe.ingredients.map(parseIngredient);
+  const { name } = parsed[0];
+  const recipeNames = parsed.map(p => p.name.toLowerCase());
+  const distractors = pickN(FAKE_INGREDIENTS, 3, recipeNames);
+  if (distractors.length < 3) return null;
+  const { choices, correct_index } = makeChoices(name, distractors);
+  return { difficulty: 'easy', question_text: 'Which of these is an ingredient in this dish?', choices, correct_index, source_field: 'ingredients' };
+}
+
+function qIngredientIsNot(recipe: RecipeFields): GeneratedQuestion | null {
+  if (recipe.ingredients.length < 3) return null;
+  const parsed = recipe.ingredients.map(parseIngredient);
+  const recipeNames = parsed.map(p => p.name);
+  const fakes = pickN(FAKE_INGREDIENTS, 1, recipeNames.map(n => n.toLowerCase()));
+  if (!fakes.length) return null;
+  const distractors = shuffle(recipeNames).slice(0, 3);
+  if (distractors.length < 3) return null;
+  const { choices, correct_index } = makeChoices(fakes[0], distractors);
+  return { difficulty: 'easy', question_text: 'Which of these is NOT an ingredient in this dish?', choices, correct_index, source_field: 'ingredients' };
+}
+
+function qCookStep(recipe: RecipeFields, idx: number): GeneratedQuestion | null {
+  const steps = recipe.cook_steps;
+  if (!steps.length) return null;
+  const allSteps = [...steps, ...recipe.plate_steps];
+  if (allSteps.length < 4) return null;
+  const step = steps[idx % steps.length];
+  const correct = trunc(step);
+  const pool = allSteps.filter(s => s !== step).map(s => trunc(s));
+  const distractors = pickN(pool, 3, [correct]);
+  if (distractors.length < 3) return null;
+  const { choices, correct_index } = makeChoices(correct, distractors);
+  return { difficulty: 'easy', question_text: `What happens in cook step ${(idx % steps.length) + 1}?`, choices, correct_index, source_field: 'cook_steps' };
+}
+
+function qPlateStep(recipe: RecipeFields, idx: number): GeneratedQuestion | null {
+  const steps = recipe.plate_steps;
+  if (!steps.length) return null;
+  const allSteps = [...recipe.cook_steps, ...steps];
+  if (allSteps.length < 4) return null;
+  const step = steps[idx % steps.length];
+  const correct = trunc(step);
+  const pool = allSteps.filter(s => s !== step).map(s => trunc(s));
+  const distractors = pickN(pool, 3, [correct]);
+  if (distractors.length < 3) return null;
+  const { choices, correct_index } = makeChoices(correct, distractors);
+  return { difficulty: 'easy', question_text: `What happens in plating step ${(idx % steps.length) + 1}?`, choices, correct_index, source_field: 'plate_steps' };
+}
+
+// ---------------------------------------------------------------------------
+// Hard generators
+// ---------------------------------------------------------------------------
+
+function qStepAfter(recipe: RecipeFields, idx: number): GeneratedQuestion | null {
+  const steps = recipe.cook_steps;
+  if (steps.length < 3) return null;
+  const i = idx % (steps.length - 1);
+  const correct = trunc(steps[i + 1]);
+  const pool = steps.filter((_, j) => j !== i && j !== i + 1).map(s => trunc(s));
+  const distractors = pickN(pool, 3, [correct]);
+  if (distractors.length < 3) return null;
+  const { choices, correct_index } = makeChoices(correct, distractors);
+  return {
+    difficulty: 'hard',
+    question_text: `In the cook process, what step comes AFTER:\n"${trunc(steps[i], 80)}"`,
+    choices, correct_index, source_field: 'cook_steps',
+  };
+}
+
+function qIngredientQty(recipe: RecipeFields): GeneratedQuestion | null {
+  const withQty = recipe.ingredients.map(parseIngredient).filter(p => p.qty);
+  if (!withQty.length) return null;
+  const { qty, name } = withQty[0];
+  const distractors = pickN(FAKE_QUANTITIES, 3, [qty]);
+  if (distractors.length < 3) return null;
+  const { choices, correct_index } = makeChoices(qty, distractors);
+  return { difficulty: 'hard', question_text: `How much ${name} does this recipe use?`, choices, correct_index, source_field: 'ingredients' };
+}
+
+function qStepCount(recipe: RecipeFields, field: 'cook_steps' | 'plate_steps'): GeneratedQuestion | null {
+  const steps = recipe[field];
+  if (!steps.length) return null;
+  const n = steps.length;
+  const opts = shuffle([n - 2, n - 1, n + 1, n + 2, n + 3].filter(x => x > 0 && x !== n)).slice(0, 3);
+  if (opts.length < 3) return null;
+  const { choices, correct_index } = makeChoices(String(n), opts.map(String));
+  const label = field === 'cook_steps' ? 'cook' : 'plating';
+  return { difficulty: 'hard', question_text: `How many ${label} steps does this recipe have?`, choices, correct_index, source_field: field };
+}
+
+// ---------------------------------------------------------------------------
+// Main export
+// ---------------------------------------------------------------------------
+
+export function generateQuestions(recipe: RecipeFields): GeneratedQuestion[] {
+  const qs: GeneratedQuestion[] = [];
+
+  push(qs, qPlateware(recipe));
+  push(qs, qIngredientIs(recipe));
+  push(qs, qIngredientIsNot(recipe));
+  for (let i = 0; i < Math.min(recipe.cook_steps.length, 3); i++) push(qs, qCookStep(recipe, i));
+  for (let i = 0; i < Math.min(recipe.plate_steps.length, 2); i++) push(qs, qPlateStep(recipe, i));
+
+  for (let i = 0; i < Math.min(Math.max(recipe.cook_steps.length - 1, 0), 3); i++) push(qs, qStepAfter(recipe, i));
+  push(qs, qIngredientQty(recipe));
+  push(qs, qStepCount(recipe, 'cook_steps'));
+  push(qs, qStepCount(recipe, 'plate_steps'));
+
+  return qs;
+}

--- a/src/scripts/seed-questions.ts
+++ b/src/scripts/seed-questions.ts
@@ -1,0 +1,61 @@
+/**
+ * Generate and store quiz questions for all published recipes.
+ * Run with: npm run seed:questions
+ * Idempotent — skips recipes that already have questions.
+ */
+import { mkdirSync } from 'fs';
+import path from 'path';
+import { createClient } from '@libsql/client';
+import { drizzle } from 'drizzle-orm/libsql';
+import { recipes, quizQuestions } from '../db/schema';
+import { eq } from 'drizzle-orm';
+import { generateQuestions } from '../lib/quiz-generator';
+
+mkdirSync(path.join(process.cwd(), 'data'), { recursive: true });
+
+const client = createClient({
+  url: `file:${path.join(process.cwd(), 'data/dev.db')}`,
+});
+const db = drizzle(client);
+
+async function seedQuestions() {
+  const allRecipes = await db
+    .select()
+    .from(recipes)
+    .where(eq(recipes.status, 'published'));
+
+  console.log(`🧩 Generating questions for ${allRecipes.length} recipes…`);
+
+  let generated = 0;
+  let skipped = 0;
+
+  for (const recipe of allRecipes) {
+    const existing = await db
+      .select({ id: quizQuestions.id })
+      .from(quizQuestions)
+      .where(eq(quizQuestions.recipe_id, recipe.id))
+      .limit(1);
+
+    if (existing.length > 0) {
+      skipped++;
+      continue;
+    }
+
+    const questions = generateQuestions(recipe);
+    if (questions.length > 0) {
+      await db.insert(quizQuestions).values(
+        questions.map(q => ({ ...q, recipe_id: recipe.id })),
+      );
+    }
+    console.log(`  ✓  ${recipe.title}: ${questions.filter(q => q.difficulty === 'easy').length} easy, ${questions.filter(q => q.difficulty === 'hard').length} hard`);
+    generated++;
+  }
+
+  console.log(`\n✅ Done — ${generated} recipes with new questions, ${skipped} already had questions`);
+  process.exit(0);
+}
+
+seedQuestions().catch(err => {
+  console.error('❌ Failed:', err);
+  process.exit(1);
+});


### PR DESCRIPTION
## Summary

- **Question generator** (`src/lib/quiz-generator.ts`): pure function that builds a pool of easy + hard multiple-choice questions from recipe fields — no LLM, no external API. Easy: plateware recall, ingredient IS/IS-NOT, cook step content, plate step content. Hard: step ordering (what comes after X?), ingredient quantity, step count.
- **Seed script** (`src/scripts/seed-questions.ts`): populates `QuizQuestion` table for all published recipes; idempotent (skips if questions exist). New `npm run seed:questions` / `npm run seed:all` commands.
- **GET `/api/quiz/[recipeId]`**: returns 5 randomly-selected easy + 3 hard questions from the stored pool; lazy-generates if none exist yet.
- **POST `/api/quiz/answer`**: records a row in the `Metric` table (`recipe_id`, `question_id`, `correct`, `role`, `language`, `timestamp`). Fire-and-forget from the client.
- **`QuizDrawer`** (`src/components/QuizDrawer.tsx`): bottom-sheet drawer — easy flow (5 Qs one at a time with A/B/C/D choices + correct/incorrect feedback), easy result screen with score + "Try 3 harder questions?" offer, hard flow (3 Qs), combined final score screen.
- **Recipe detail page**: quiz FAB (dark navy, quiz icon) stacked above the existing chat FAB; both connect to their respective drawers via `RecipeActions`.

## Test plan

- [ ] Log in as `linecook` and open any recipe detail page
- [ ] Tap the quiz FAB (dark icon above the chat icon) — drawer slides up
- [ ] Tap "Start Quiz" — 5 easy questions load, one at a time with 4 choices
- [ ] Select an answer — correct/incorrect feedback shows immediately, "Next" advances
- [ ] After Q5 — result screen shows score and "Try 3 harder questions" button
- [ ] Accept hard follow-up — 3 hard questions run (step ordering, ingredient qty, step count)
- [ ] Final result screen shows combined score; "Done" closes drawer
- [ ] `npm run seed:questions` is idempotent (re-running skips existing recipes)
- [ ] `POST /api/quiz/answer` returns `{"ok":true}` and a row appears in `metrics`

🤖 Generated with [Claude Code](https://claude.com/claude-code)