### PR TITLE
feat(admin): CSV bulk import for recipes — closes #12

### DIFF
--- a/src/app/(admin)/admin/recipes/ImportButton.tsx
+++ b/src/app/(admin)/admin/recipes/ImportButton.tsx
@@ -1,0 +1,144 @@
+'use client';
+
+import { useRef, useState } from 'react';
+import { useRouter } from 'next/navigation';
+
+interface ImportSummary {
+  inserted: number;
+  updated: number;
+  failed: number;
+  errors: string[];
+}
+
+export default function ImportButton() {
+  const router = useRouter();
+  const inputRef = useRef<HTMLInputElement>(null);
+  const [loading, setLoading] = useState(false);
+  const [summary, setSummary] = useState<ImportSummary | null>(null);
+  const [error, setError] = useState<string | null>(null);
+
+  async function onFile(e: React.ChangeEvent<HTMLInputElement>) {
+    const file = e.target.files?.[0];
+    if (!file) return;
+
+    setLoading(true);
+    setError(null);
+    setSummary(null);
+
+    const fd = new FormData();
+    fd.append('file', file);
+
+    try {
+      const res = await fetch('/api/admin/import', { method: 'POST', body: fd });
+      const data = await res.json();
+      if (!res.ok) {
+        setError(data.error ?? `Import failed (${res.status})`);
+      } else {
+        setSummary(data as ImportSummary);
+      }
+    } catch (err) {
+      setError(err instanceof Error ? err.message : 'Network error');
+    } finally {
+      setLoading(false);
+      if (inputRef.current) inputRef.current.value = '';
+    }
+  }
+
+  function close() {
+    setSummary(null);
+    setError(null);
+    router.refresh();
+  }
+
+  return (
+    <>
+      <button
+        type="button"
+        disabled={loading}
+        onClick={() => inputRef.current?.click()}
+        className="flex items-center gap-1 px-4 py-2 bg-white text-[#001b3c] border-2 border-[#001b3c] font-grotesk font-bold uppercase tracking-wide text-xs hover:bg-[#f0f3ff] transition-colors disabled:opacity-50 disabled:cursor-wait"
+      >
+        <span className="material-symbols-outlined text-base">upload_file</span>
+        {loading ? 'IMPORTING…' : 'IMPORT CSV'}
+      </button>
+      <input
+        ref={inputRef}
+        type="file"
+        accept=".csv,text/csv"
+        onChange={onFile}
+        className="hidden"
+      />
+
+      {(summary || error) && (
+        <div className="fixed inset-0 z-[60] bg-[#001b3c]/40 flex items-center justify-center p-4">
+          <div className="bg-white border-2 border-[#001b3c] max-w-lg w-full max-h-[80vh] flex flex-col">
+            <div className="px-5 py-3 border-b-2 border-[#001b3c] bg-[#e7eeff] flex items-center justify-between">
+              <h2 className="font-grotesk font-black uppercase text-[#001b3c] tracking-tight">
+                Import Result
+              </h2>
+              <button
+                type="button"
+                onClick={close}
+                className="text-[#526a8d] hover:text-[#001b3c]"
+                aria-label="Close"
+              >
+                <span className="material-symbols-outlined">close</span>
+              </button>
+            </div>
+
+            <div className="px-5 py-4 overflow-auto">
+              {error ? (
+                <p className="font-sans text-[#b7102a]">{error}</p>
+              ) : summary ? (
+                <>
+                  <div className="grid grid-cols-3 gap-2 mb-4">
+                    <Stat label="Inserted" value={summary.inserted} tone="ok" />
+                    <Stat label="Updated" value={summary.updated} tone="info" />
+                    <Stat label="Failed" value={summary.failed} tone={summary.failed > 0 ? 'err' : 'mute'} />
+                  </div>
+                  {summary.errors.length > 0 && (
+                    <div>
+                      <h3 className="font-grotesk font-bold uppercase text-xs tracking-wide text-[#001b3c] mb-2">
+                        Errors
+                      </h3>
+                      <ul className="font-sans text-sm text-[#43474e] space-y-1 max-h-60 overflow-auto border border-[#e7eeff] p-3 bg-[#f9f9ff]">
+                        {summary.errors.map((e, i) => (
+                          <li key={i} className="border-b border-[#e7eeff] pb-1 last:border-0">{e}</li>
+                        ))}
+                      </ul>
+                    </div>
+                  )}
+                </>
+              ) : null}
+            </div>
+
+            <div className="px-5 py-3 border-t-2 border-[#001b3c] flex justify-end">
+              <button
+                type="button"
+                onClick={close}
+                className="px-5 py-2 bg-[#526a8d] text-white border-2 border-[#001b3c] font-grotesk font-bold uppercase tracking-wide text-xs hover:bg-[#3a5273] transition-colors"
+              >
+                Done
+              </button>
+            </div>
+          </div>
+        </div>
+      )}
+    </>
+  );
+}
+
+function Stat({ label, value, tone }: { label: string; value: number; tone: 'ok' | 'info' | 'err' | 'mute' }) {
+  const toneClass = {
+    ok: 'border-[#1a7a45] text-[#1a7a45] bg-[#d6f5e3]',
+    info: 'border-[#526a8d] text-[#526a8d] bg-[#e7eeff]',
+    err: 'border-[#b7102a] text-[#b7102a] bg-[#fde0e4]',
+    mute: 'border-[#74777f] text-[#74777f] bg-[#f5f5f5]',
+  }[tone];
+  return (
+    <div className={`border-2 px-3 py-2 ${toneClass}`}>
+      <div className="font-grotesk font-black text-2xl leading-none">{value}</div>
+      <div className="font-grotesk font-bold uppercase text-[10px] tracking-wide mt-1">{label}</div>
+    </div>
+  );
+}

--- a/src/app/(admin)/admin/recipes/RecipeAdminList.tsx
+++ b/src/app/(admin)/admin/recipes/RecipeAdminList.tsx
@@ -3,6 +3,7 @@
 import { useMemo, useState } from 'react';
 import Link from 'next/link';
 import type { RecipeRow } from '@/db/recipes';
+import ImportButton from './ImportButton';
 
 type StatusFilter = 'ALL' | 'draft' | 'published' | 'archived';
 
@@ -37,13 +38,16 @@ export default function RecipeAdminList({ initialRecipes }: { initialRecipes: Re
             RECIPE MANAGEMENT
           </span>
         </div>
-        <Link
-          href="/admin/recipes/new"
-          className="flex items-center gap-1 px-4 py-2 bg-[#526a8d] text-white border-2 border-[#001b3c] font-grotesk font-bold uppercase tracking-wide text-xs hover:bg-[#3a5273] transition-colors"
-        >
-          <span className="material-symbols-outlined text-base">add</span>
-          NEW RECIPE
-        </Link>
+        <div className="flex items-center gap-2">
+          <ImportButton />
+          <Link
+            href="/admin/recipes/new"
+            className="flex items-center gap-1 px-4 py-2 bg-[#526a8d] text-white border-2 border-[#001b3c] font-grotesk font-bold uppercase tracking-wide text-xs hover:bg-[#3a5273] transition-colors"
+          >
+            <span className="material-symbols-outlined text-base">add</span>
+            NEW RECIPE
+          </Link>
+        </div>
       </header>
 
       <main className="pt-[64px] pb-10 px-6 max-w-5xl mx-auto">

--- a/src/app/api/admin/import/route.ts
+++ b/src/app/api/admin/import/route.ts
@@ -1,0 +1,124 @@
+import { NextRequest, NextResponse } from 'next/server';
+import { eq } from 'drizzle-orm';
+import { db } from '@/db';
+import { recipes, quizQuestions } from '@/db/schema';
+import { listRecipes } from '@/db/recipes';
+import { verifySession, COOKIE_NAME } from '@/lib/session';
+import { parseCsvText, parsePipeArray } from '@/lib/csv';
+import { buildDistractorPool, generateQuestionsForRecipe } from '@/lib/quiz-generator';
+
+const REQUIRED_COLUMNS = ['title', 'recipe_type', 'ingredients', 'cook_steps', 'plate_steps'];
+const MAX_BYTES = 2 * 1024 * 1024; // 2 MB
+
+export interface ImportSummary {
+  inserted: number;
+  updated: number;
+  failed: number;
+  errors: string[];
+}
+
+async function getRole(req: NextRequest) {
+  const cookieValue = req.cookies.get(COOKIE_NAME)?.value ?? null;
+  return cookieValue ? await verifySession(cookieValue) : null;
+}
+
+export async function POST(req: NextRequest) {
+  const role = await getRole(req);
+  if (role !== 'admin') return NextResponse.json({ error: 'Unauthorized' }, { status: 401 });
+
+  const formData = await req.formData();
+  const file = formData.get('file');
+  if (!(file instanceof File)) {
+    return NextResponse.json({ error: 'Missing file field' }, { status: 400 });
+  }
+  if (file.size > MAX_BYTES) {
+    return NextResponse.json({ error: 'File exceeds 2MB limit' }, { status: 400 });
+  }
+
+  const text = await file.text();
+  const { headers, rows } = parseCsvText(text);
+  const missing = REQUIRED_COLUMNS.filter(c => !headers.includes(c));
+  if (missing.length > 0) {
+    return NextResponse.json(
+      { error: `Missing required columns: ${missing.join(', ')}` },
+      { status: 400 },
+    );
+  }
+
+  const summary: ImportSummary = { inserted: 0, updated: 0, failed: 0, errors: [] };
+  const newRecipeIds: string[] = [];
+
+  for (let i = 0; i < rows.length; i++) {
+    const rowNum = i + 2; // header is line 1
+    const row = rows[i];
+    const title = row.title?.trim();
+
+    if (!title) {
+      summary.failed++;
+      summary.errors.push(`row ${rowNum}: missing title`);
+      continue;
+    }
+
+    try {
+      const record = {
+        title,
+        recipe_type: row.recipe_type?.trim() || 'Core',
+        station: row.station?.trim() || null,
+        is_new: row.is_new?.trim().toLowerCase() === 'true',
+        yield: row.yield?.trim() || null,
+        prep_time: row.prep_time?.trim() || null,
+        shelf_life: row.shelf_life?.trim() || null,
+        original_date: row.original_date?.trim() || null,
+        revision_date: row.revision_date?.trim() || null,
+        plateware: row.plateware?.trim() || null,
+        ingredients: parsePipeArray(row.ingredients ?? ''),
+        cook_steps: parsePipeArray(row.cook_steps ?? ''),
+        plate_steps: parsePipeArray(row.plate_steps ?? ''),
+        allergens: parsePipeArray(row.allergens ?? ''),
+        marketing_lore: row.marketing_lore?.trim() || null,
+        status: ((row.status?.trim() as 'draft' | 'published' | 'archived') || 'published'),
+        updated_at: new Date(),
+      };
+
+      const existing = await db
+        .select({ id: recipes.id })
+        .from(recipes)
+        .where(eq(recipes.title, title))
+        .limit(1);
+
+      if (existing.length > 0) {
+        await db.update(recipes).set(record).where(eq(recipes.title, title));
+        summary.updated++;
+      } else {
+        const [inserted] = await db.insert(recipes).values(record).returning({ id: recipes.id });
+        summary.inserted++;
+        if (inserted?.id) newRecipeIds.push(inserted.id);
+      }
+    } catch (err) {
+      summary.failed++;
+      const msg = err instanceof Error ? err.message : String(err);
+      summary.errors.push(`row ${rowNum} (${title}): ${msg}`);
+    }
+  }
+
+  // Generate quiz questions for newly inserted recipes only.
+  if (newRecipeIds.length > 0) {
+    const allRecipes = await listRecipes();
+    const pool = buildDistractorPool(allRecipes);
+    const newRecipes = allRecipes.filter(r => newRecipeIds.includes(r.id));
+
+    for (const recipe of newRecipes) {
+      try {
+        const questions = generateQuestionsForRecipe(recipe, pool);
+        if (questions.length > 0) {
+          await db.insert(quizQuestions).values(questions);
+        }
+      } catch (err) {
+        const msg = err instanceof Error ? err.message : String(err);
+        summary.errors.push(`quiz-gen for ${recipe.title}: ${msg}`);
+      }
+    }
+  }
+
+  return NextResponse.json(summary);
+}

--- a/src/lib/csv.ts
+++ b/src/lib/csv.ts
@@ -1,0 +1,54 @@
+/**
+ * Shared CSV parsing utilities.
+ * RFC 4180 quoted-field handling; pipe-delimited array columns.
+ * Used by the seed script and the admin bulk-import endpoint.
+ */
+
+export function parseCsvLine(line: string): string[] {
+  const fields: string[] = [];
+  let current = '';
+  let inQuotes = false;
+
+  for (let i = 0; i < line.length; i++) {
+    const ch = line[i];
+    if (ch === '"') {
+      if (inQuotes && line[i + 1] === '"') {
+        current += '"';
+        i++;
+      } else {
+        inQuotes = !inQuotes;
+      }
+    } else if (ch === ',' && !inQuotes) {
+      fields.push(current);
+      current = '';
+    } else {
+      current += ch;
+    }
+  }
+  fields.push(current);
+  return fields;
+}
+
+export function parsePipeArray(raw: string): string[] {
+  if (!raw.trim()) return [];
+  return raw.split('|').map(s => s.trim()).filter(Boolean);
+}
+
+export interface ParsedCsv {
+  headers: string[];
+  rows: Record<string, string>[];
+}
+
+export function parseCsvText(raw: string): ParsedCsv {
+  const lines = raw.split(/\r?\n/).filter(Boolean);
+  if (lines.length === 0) return { headers: [], rows: [] };
+
+  const headers = parseCsvLine(lines[0]).map(h => h.trim());
+  const rows = lines.slice(1).map(line => {
+    const values = parseCsvLine(line);
+    const row: Record<string, string> = {};
+    headers.forEach((h, i) => { row[h] = values[i] ?? ''; });
+    return row;
+  });
+  return { headers, rows };
+}

--- a/src/lib/quiz-generator.ts
+++ b/src/lib/quiz-generator.ts
@@ -1,0 +1,153 @@
+/**
+ * Deterministic quiz-question generator — builds template questions from recipe
+ * fields. Same recipe id always yields the same questions/order so re-running
+ * import on a brand-new DB produces stable output.
+ *
+ * No LLM. Future versions can swap the body of `generateQuestionsForRecipe`
+ * without changing callers.
+ */
+import type { RecipeRow } from '@/db/recipes';
+import type { quizQuestions } from '@/db/schema';
+
+export type NewQuizQuestion = Omit<typeof quizQuestions.$inferInsert, 'id' | 'created_at'>;
+
+const STATIONS = ['Saute', 'Grill', 'Fryer', 'Pantry', 'Pizza'];
+const PREP_DECOYS = ['5 min', '15 min', '30 min', '1 hour'];
+
+/** Tiny seeded RNG (mulberry32) — stable across runs for a given seed. */
+function rngFromString(seed: string): () => number {
+  let h = 1779033703 ^ seed.length;
+  for (let i = 0; i < seed.length; i++) {
+    h = Math.imul(h ^ seed.charCodeAt(i), 3432918353);
+    h = (h << 13) | (h >>> 19);
+  }
+  let a = h >>> 0;
+  return () => {
+    a = (a + 0x6d2b79f5) | 0;
+    let t = a;
+    t = Math.imul(t ^ (t >>> 15), t | 1);
+    t ^= t + Math.imul(t ^ (t >>> 7), t | 61);
+    return ((t ^ (t >>> 14)) >>> 0) / 4294967296;
+  };
+}
+
+function shuffle<T>(arr: T[], rand: () => number): T[] {
+  const out = arr.slice();
+  for (let i = out.length - 1; i > 0; i--) {
+    const j = Math.floor(rand() * (i + 1));
+    [out[i], out[j]] = [out[j], out[i]];
+  }
+  return out;
+}
+
+/** Pick `count` distinct items from `pool` excluding any in `exclude`. */
+function pickDistractors(
+  pool: string[],
+  exclude: Set<string>,
+  count: number,
+  rand: () => number,
+): string[] {
+  const candidates = Array.from(new Set(pool)).filter(p => p && !exclude.has(p));
+  const shuffled = shuffle(candidates, rand);
+  return shuffled.slice(0, count);
+}
+
+function buildChoices(
+  correct: string,
+  distractors: string[],
+  rand: () => number,
+): { choices: string[]; correct_index: number } {
+  const choices = shuffle([correct, ...distractors], rand);
+  return { choices, correct_index: choices.indexOf(correct) };
+}
+
+export interface DistractorPool {
+  ingredients: string[];
+  cookSteps: string[];
+}
+
+export function buildDistractorPool(allRecipes: RecipeRow[]): DistractorPool {
+  const ingredients: string[] = [];
+  const cookSteps: string[] = [];
+  for (const r of allRecipes) {
+    if (Array.isArray(r.ingredients)) ingredients.push(...r.ingredients);
+    if (Array.isArray(r.cook_steps)) cookSteps.push(...r.cook_steps);
+  }
+  return { ingredients, cookSteps };
+}
+
+export function generateQuestionsForRecipe(
+  recipe: RecipeRow,
+  pool: DistractorPool,
+): NewQuizQuestion[] {
+  const rand = rngFromString(recipe.id);
+  const out: NewQuizQuestion[] = [];
+
+  // Easy: station
+  if (recipe.station) {
+    const distractors = STATIONS.filter(s => s !== recipe.station).slice(0, 3);
+    const { choices, correct_index } = buildChoices(recipe.station, distractors, rand);
+    out.push({
+      recipe_id: recipe.id,
+      difficulty: 'easy',
+      question_text: `What station is ${recipe.title} cooked on?`,
+      choices,
+      correct_index,
+      source_field: 'station',
+    });
+  }
+
+  // Easy: prep_time
+  if (recipe.prep_time) {
+    const distractors = PREP_DECOYS.filter(d => d !== recipe.prep_time).slice(0, 3);
+    const { choices, correct_index } = buildChoices(recipe.prep_time, distractors, rand);
+    out.push({
+      recipe_id: recipe.id,
+      difficulty: 'easy',
+      question_text: `What is the prep time for ${recipe.title}?`,
+      choices,
+      correct_index,
+      source_field: 'prep_time',
+    });
+  }
+
+  // Hard: ingredient
+  const ingredients = recipe.ingredients ?? [];
+  if (ingredients.length > 0) {
+    const correct = ingredients[0];
+    const exclude = new Set(ingredients);
+    const distractors = pickDistractors(pool.ingredients, exclude, 3, rand);
+    if (distractors.length === 3) {
+      const { choices, correct_index } = buildChoices(correct, distractors, rand);
+      out.push({
+        recipe_id: recipe.id,
+        difficulty: 'hard',
+        question_text: `Which ingredient is in ${recipe.title}?`,
+        choices,
+        correct_index,
+        source_field: 'ingredients',
+      });
+    }
+  }
+
+  // Hard: first cook step
+  const cookSteps = recipe.cook_steps ?? [];
+  if (cookSteps.length > 0) {
+    const correct = cookSteps[0];
+    const exclude = new Set(cookSteps);
+    const distractors = pickDistractors(pool.cookSteps, exclude, 3, rand);
+    if (distractors.length === 3) {
+      const { choices, correct_index } = buildChoices(correct, distractors, rand);
+      out.push({
+        recipe_id: recipe.id,
+        difficulty: 'hard',
+        question_text: `Which is the first cook step for ${recipe.title}?`,
+        choices,
+        correct_index,
+        source_field: 'cook_steps',
+      });
+    }
+  }
+
+  return out;
+}

--- a/src/scripts/seed-from-csv.ts
+++ b/src/scripts/seed-from-csv.ts
@@ -9,6 +9,7 @@ import { createClient } from '@libsql/client';
 import { drizzle } from 'drizzle-orm/libsql';
 import { recipes } from '../db/schema';
 import { eq } from 'drizzle-orm';
+import { parseCsvLine, parsePipeArray } from '../lib/csv';
 
 // ---------------------------------------------------------------------------
 // DB setup (mirrors src/db/index.ts but standalone — no Next.js context)
@@ -19,41 +20,6 @@ const client = createClient({
   url: `file:${path.join(process.cwd(), 'data/dev.db')}`,
 });
 const db = drizzle(client);
-
-// ---------------------------------------------------------------------------
-// CSV parser — handles quoted fields and pipe-delimited array columns
-// ---------------------------------------------------------------------------
-const ARRAY_COLUMNS = new Set(['ingredients', 'cook_steps', 'plate_steps', 'allergens']);
-
-function parseCsvLine(line: string): string[] {
-  const fields: string[] = [];
-  let current = '';
-  let inQuotes = false;
-
-  for (let i = 0; i < line.length; i++) {
-    const ch = line[i];
-    if (ch === '"') {
-      if (inQuotes && line[i + 1] === '"') {
-        current += '"';
-        i++;
-      } else {
-        inQuotes = !inQuotes;
-      }
-    } else if (ch === ',' && !inQuotes) {
-      fields.push(current);
-      current = '';
-    } else {
-      current += ch;
-    }
-  }
-  fields.push(current);
-  return fields;
-}
-
-function parsePipeArray(raw: string): string[] {
-  if (!raw.trim()) return [];
-  return raw.split('|').map(s => s.trim()).filter(Boolean);
-}
 
 // ---------------------------------------------------------------------------
 // Main


### PR DESCRIPTION
## Summary
- Adds a Manager-facing CSV upload to `/admin/recipes` (button next to **NEW RECIPE**)
- New `POST /api/admin/import` endpoint: multipart upload, admin-gated, 2MB cap; upserts by title (matching seed-script semantics), reports per-row errors, and continues on failure
- New deterministic quiz generator (`src/lib/quiz-generator.ts`) — no LLM, seeded RNG so output is stable per recipe id. Generates up to 4 template questions per *newly inserted* recipe (station, prep_time, ingredient, first cook step). Updated recipes' existing questions are preserved per the AC.
- Extracted CSV parsing into `src/lib/csv.ts`; seed script now imports from it

## Notes
- The original brief said the admin shell needed to be scaffolded — it already exists (issue #9 landed). Just wired the button into the existing `RecipeAdminList` header.
- The brief referenced `src/lib/quiz-generator.ts` and `src/scripts/seed-questions.ts` as if they existed — they didn't, so this PR creates the generator from scratch as a deterministic template engine. Future LLM-based generation can swap the body of `generateQuestionsForRecipe` without changing callers.

## Test plan
- [ ] Build passes (`npm run build` ✅)
- [ ] Login as admin (`admin` / `admin`), open `/admin/recipes`, click **IMPORT CSV**
- [ ] Upload a CSV with one new title, one matching an existing title, one with empty title — verify summary shows `1 inserted, 1 updated, 1 failed` and the error row is listed
- [ ] Verify new recipe gets 2-4 quiz questions; updated recipe's existing questions are untouched
- [ ] Verify required-column validation: upload CSV missing `cook_steps` → 400 with column name in error
- [ ] Verify auth: POST `/api/admin/import` without session cookie → 401

🤖 Generated with [Claude Code](https://claude.com/claude-code)