### PR TITLE
feat(linecook): inline 'Quiz Yourself' CTA at bottom of recipe

### DIFF
--- a/src/app/(linecook)/dashboard/[id]/QuizCTA.tsx
+++ b/src/app/(linecook)/dashboard/[id]/QuizCTA.tsx
@@ -1,0 +1,41 @@
+'use client';
+
+import { useState } from 'react';
+import { QuizDrawer } from '@/components/QuizDrawer';
+
+export default function QuizCTA({
+  recipeId,
+  recipeTitle,
+}: {
+  recipeId: string;
+  recipeTitle: string;
+}) {
+  const [open, setOpen] = useState(false);
+
+  return (
+    <>
+      <section className="px-6 pt-2 pb-6">
+        <button
+          type="button"
+          onClick={() => setOpen(true)}
+          className="w-full flex items-center justify-center gap-3 bg-[#001b3c] text-white border-2 border-[#001b3c] py-5 font-grotesk font-black uppercase tracking-widest text-base hover:bg-[#526a8d] active:bg-[#3d5270] transition-colors"
+        >
+          <span
+            className="material-symbols-outlined text-2xl"
+            style={{ fontVariationSettings: "'FILL' 1" }}
+          >
+            quiz
+          </span>
+          Quiz Yourself On This Recipe
+        </button>
+      </section>
+
+      <QuizDrawer
+        isOpen={open}
+        onClose={() => setOpen(false)}
+        recipeId={recipeId}
+        recipeTitle={recipeTitle}
+      />
+    </>
+  );
+}

--- a/src/app/(linecook)/dashboard/[id]/RecipeActions.tsx
+++ b/src/app/(linecook)/dashboard/[id]/RecipeActions.tsx
@@ -2,31 +2,12 @@
 
 import { useState } from 'react';
 import { ChatDrawer } from '@/components/ChatDrawer';
-import { QuizDrawer } from '@/components/QuizDrawer';
 
-export default function RecipeActions({
-  recipeId,
-  recipeTitle,
-}: {
-  recipeId: string;
-  recipeTitle: string;
-}) {
+export default function RecipeActions({ recipeId }: { recipeId: string }) {
   const [chatOpen, setChatOpen] = useState(false);
-  const [quizOpen, setQuizOpen] = useState(false);
 
   return (
     <>
-      {/* Quiz FAB — sits above chat FAB */}
-      <button
-        onClick={() => setQuizOpen(true)}
-        aria-label="Quiz yourself on this recipe"
-        className="fixed bottom-[172px] right-6 w-14 h-14 bg-[#001b3c] rounded-full shadow-xl flex items-center justify-center text-white hover:bg-[#526a8d] active:bg-[#3d5270] transition-colors z-40"
-      >
-        <span className="material-symbols-outlined text-2xl" style={{ fontVariationSettings: "'FILL' 1" }}>
-          quiz
-        </span>
-      </button>
-
       {/* Chat FAB */}
       <button
         onClick={() => setChatOpen(true)}
@@ -53,13 +34,6 @@ export default function RecipeActions({
         isOpen={chatOpen}
         onClose={() => setChatOpen(false)}
         recipeId={recipeId}
-      />
-
-      <QuizDrawer
-        isOpen={quizOpen}
-        onClose={() => setQuizOpen(false)}
-        recipeId={recipeId}
-        recipeTitle={recipeTitle}
       />
     </>
   );

--- a/src/app/(linecook)/dashboard/[id]/page.tsx
+++ b/src/app/(linecook)/dashboard/[id]/page.tsx
@@ -2,6 +2,7 @@ import { getRecipe } from '@/db/recipes';
 import { notFound } from 'next/navigation';
 import Link from 'next/link';
 import RecipeActions from './RecipeActions';
+import QuizCTA from './QuizCTA';
 
 export const dynamic = 'force-dynamic';
 
@@ -177,6 +178,9 @@ export default async function RecipeDetailPage({
             </section>
           )}
         </div>
+
+        {/* Quiz CTA — sits at the end of the recipe content */}
+        <QuizCTA recipeId={recipe.id} recipeTitle={recipe.title} />
       </main>
 
       {/* Bottom Nav */}
@@ -205,8 +209,8 @@ export default async function RecipeDetailPage({
         ))}
       </nav>
 
-      {/* FABs + Drawers (client) */}
-      <RecipeActions recipeId={recipe.id} recipeTitle={recipe.title} />
+      {/* Chat FAB + Drawer (client) */}
+      <RecipeActions recipeId={recipe.id} />
     </div>
   );
 }


### PR DESCRIPTION
## Summary
- Replaces the floating Quiz FAB (which sat above the chat bubble and was easy to miss) with a full-width dark CTA button rendered inline at the end of each recipe's content
- Chat FAB stays in its floating slot — only the quiz entry point moved
- New `QuizCTA` client component owns the button + drawer state; `RecipeActions` now only handles the chat FAB

## Test plan
- [ ] Build passes (`npm run build` ✅)
- [ ] On `/dashboard/[id]`: scroll to the bottom of the recipe — see "QUIZ YOURSELF ON THIS RECIPE" button
- [ ] Tap it → QuizDrawer opens, easy round → hard round flow still works
- [ ] Chat bubble (bottom-right) still works
- [ ] No leftover floating quiz icon

🤖 Generated with [Claude Code](https://claude.com/claude-code)