### PR TITLE
feat(ux): dashboard explainer, quiz history, settings + logout, typog…

### DIFF
--- a/src/app/(linecook)/dashboard/RecipeList.tsx
+++ b/src/app/(linecook)/dashboard/RecipeList.tsx
@@ -4,6 +4,7 @@ import { useState, useMemo } from 'react';
 import Link from 'next/link';
 import type { RecipeRow } from '@/db/recipes';
 import { ChatDrawer } from '@/components/ChatDrawer';
+import { BottomNav } from '@/components/BottomNav';
 
 type FilterType = 'ALL' | 'Saute' | 'Grill' | 'Fryer' | 'Pantry' | 'Pizza';
 
@@ -36,13 +37,13 @@ export default function RecipeList({ initialRecipes }: { initialRecipes: RecipeR
       </header>
 
       {/* Main content */}
-      <main className="pt-[64px] pb-[100px] px-6 max-w-4xl mx-auto">
+      <main className="pt-[64px] pb-[100px] px-6 max-w-6xl mx-auto">
         {/* Page heading */}
         <div className="py-6 border-b-2 border-[#001b3c] mb-6">
-          <h1 className="font-grotesk font-black uppercase text-[#001b3c] text-4xl tracking-tight leading-none">
+          <h1 className="font-grotesk font-black uppercase text-[#001b3c] text-5xl md:text-6xl tracking-tight leading-none">
             GALLEY RECIPES
           </h1>
-          <p className="text-[#43474e] mt-2 text-base">Pelican Brewery Kitchen Operations</p>
+          <p className="text-[#43474e] mt-2 text-lg">Pelican Brewery Kitchen Operations</p>
         </div>
 
         {/* Search */}
@@ -56,7 +57,7 @@ export default function RecipeList({ initialRecipes }: { initialRecipes: RecipeR
               placeholder="SEARCH RECIPES"
               value={search}
               onChange={e => setSearch(e.target.value)}
-              className="h-[64px] w-full bg-white border-b-2 border-[#001b3c] pl-12 pr-4 font-grotesk uppercase tracking-widest text-[#001b3c] placeholder:text-[#74777f]/50 focus:border-2 focus:border-[#526a8d] outline-none text-sm"
+              className="h-[64px] w-full bg-white border-b-2 border-[#001b3c] pl-12 pr-4 font-grotesk uppercase tracking-widest text-[#001b3c] placeholder:text-[#74777f]/50 focus:border-2 focus:border-[#526a8d] outline-none text-base"
             />
           </div>
         </div>
@@ -67,7 +68,7 @@ export default function RecipeList({ initialRecipes }: { initialRecipes: RecipeR
             <button
               key={f}
               onClick={() => setFilter(f)}
-              className={`px-6 py-2 font-grotesk font-bold uppercase tracking-[0.1em] text-sm border-2 border-[#001b3c] transition-colors active:translate-y-[2px] active:translate-x-[2px] ${
+              className={`px-6 py-3 font-grotesk font-bold uppercase tracking-[0.1em] text-base border-2 border-[#001b3c] transition-colors active:translate-y-[2px] active:translate-x-[2px] ${
                 filter === f
                   ? 'bg-[#526a8d] text-white'
                   : 'bg-white text-[#001b3c] hover:bg-[#f0f3ff]'
@@ -126,7 +127,7 @@ function RecipeCard({ recipe }: { recipe: RecipeRow }) {
     <Link href={`/dashboard/${recipe.id}`} className="flex">
       <article className="bg-white border-2 border-[#001b3c] flex flex-col overflow-hidden hover:border-[#526a8d] transition-colors duration-200 cursor-pointer w-full group">
         {/* Placeholder band — no image field in schema */}
-        <div className="h-28 bg-[#526a8d]/10 border-b-2 border-[#001b3c] flex items-center justify-center relative">
+        <div className="h-32 bg-[#526a8d]/10 border-b-2 border-[#001b3c] flex items-center justify-center relative">
           <span className="font-grotesk font-bold uppercase tracking-[0.15em] text-xs text-[#526a8d]">
             {recipe.station ?? recipe.recipe_type}
           </span>
@@ -142,14 +143,14 @@ function RecipeCard({ recipe }: { recipe: RecipeRow }) {
 
         {/* Content */}
         <div className="flex flex-col flex-1 p-4 gap-1">
-          <h2 className="font-grotesk font-semibold uppercase text-[#001b3c] text-base leading-tight">
+          <h2 className="font-grotesk font-semibold uppercase text-[#001b3c] text-lg leading-tight">
             {recipe.title}
           </h2>
           {recipe.yield && (
-            <p className="text-[#43474e] text-sm">Yield: {recipe.yield}</p>
+            <p className="text-[#43474e] text-base">Yield: {recipe.yield}</p>
           )}
           {recipe.shelf_life && (
-            <p className="text-[#43474e] text-sm">Shelf life: {recipe.shelf_life}</p>
+            <p className="text-[#43474e] text-base">Shelf life: {recipe.shelf_life}</p>
           )}
         </div>
 
@@ -167,37 +168,3 @@ function RecipeCard({ recipe }: { recipe: RecipeRow }) {
   );
 }
 
-function BottomNav({ activeTab }: { activeTab: string }) {
-  const tabs = [
-    { id: 'dashboard', label: 'Dashboard', icon: 'dashboard', href: '/dashboard' },
-    { id: 'recipes', label: 'Recipes', icon: 'restaurant_menu', href: '/dashboard' },
-    { id: 'quizzes', label: 'Quizzes', icon: 'quiz', href: '/quiz' },
-    { id: 'settings', label: 'Settings', icon: 'settings', href: '/settings' },
-  ];
-
-  return (
-    <nav className="bg-white border-t-2 border-[#001b3c] h-[80px] fixed bottom-0 w-full flex justify-around z-40">
-      {tabs.map(tab => (
-        <Link
-          key={tab.id}
-          href={tab.href}
-          className={`flex flex-col items-center justify-center flex-1 h-full gap-1 transition-colors ${
-            tab.id === activeTab
-              ? 'bg-[#526a8d] text-white'
-              : 'text-[#001b3c] hover:bg-[#f0f3ff]'
-          }`}
-        >
-          <span
-            className="material-symbols-outlined text-2xl"
-            style={tab.id === activeTab ? { fontVariationSettings: "'FILL' 1" } : {}}
-          >
-            {tab.icon}
-          </span>
-          <span className="font-grotesk font-bold uppercase tracking-wider text-xs">
-            {tab.label}
-          </span>
-        </Link>
-      ))}
-    </nav>
-  );
-}

--- a/src/app/(linecook)/dashboard/[id]/page.tsx
+++ b/src/app/(linecook)/dashboard/[id]/page.tsx
@@ -3,6 +3,7 @@ import { notFound } from 'next/navigation';
 import Link from 'next/link';
 import RecipeActions from './RecipeActions';
 import QuizCTA from './QuizCTA';
+import { BottomNav } from '@/components/BottomNav';
 
 export const dynamic = 'force-dynamic';
 
@@ -36,13 +37,13 @@ export default async function RecipeDetailPage({
       </header>
 
       {/* Main content */}
-      <main className="pt-[64px] pb-[160px] max-w-4xl mx-auto">
+      <main className="pt-[64px] pb-[160px] max-w-6xl mx-auto">
         {/* Recipe header band */}
         <div className="bg-[#526a8d]/10 border-b-2 border-[#001b3c] px-6 py-8">
           <span className="inline-block font-grotesk font-bold uppercase tracking-widest text-xs text-[#526a8d] border border-[#526a8d] px-2 py-1 mb-3">
             {recipe.recipe_type}
           </span>
-          <h1 className="font-grotesk font-black uppercase text-[#001b3c] text-3xl leading-tight tracking-tight">
+          <h1 className="font-grotesk font-black uppercase text-[#001b3c] text-4xl md:text-5xl leading-tight tracking-tight">
             {recipe.title}
           </h1>
 
@@ -53,7 +54,7 @@ export default async function RecipeDetailPage({
                 <div className="font-grotesk font-bold uppercase tracking-wide text-xs text-[#74777f]">
                   Yield
                 </div>
-                <div className="font-grotesk font-bold text-[#001b3c] mt-1 text-sm">{recipe.yield}</div>
+                <div className="font-grotesk font-bold text-[#001b3c] mt-1 text-base">{recipe.yield}</div>
               </div>
             )}
             {recipe.prep_time && (
@@ -61,7 +62,7 @@ export default async function RecipeDetailPage({
                 <div className="font-grotesk font-bold uppercase tracking-wide text-xs text-[#74777f]">
                   Prep Time
                 </div>
-                <div className="font-grotesk font-bold text-[#001b3c] mt-1 text-sm">{recipe.prep_time}</div>
+                <div className="font-grotesk font-bold text-[#001b3c] mt-1 text-base">{recipe.prep_time}</div>
               </div>
             )}
             {recipe.shelf_life && (
@@ -69,7 +70,7 @@ export default async function RecipeDetailPage({
                 <div className="font-grotesk font-bold uppercase tracking-wide text-xs text-[#74777f]">
                   Shelf Life
                 </div>
-                <div className="font-grotesk font-bold text-[#001b3c] mt-1 text-sm">{recipe.shelf_life}</div>
+                <div className="font-grotesk font-bold text-[#001b3c] mt-1 text-base">{recipe.shelf_life}</div>
               </div>
             )}
             {recipe.plateware && (
@@ -77,7 +78,7 @@ export default async function RecipeDetailPage({
                 <div className="font-grotesk font-bold uppercase tracking-wide text-xs text-[#74777f]">
                   Plateware
                 </div>
-                <div className="font-grotesk font-bold text-[#001b3c] mt-1 text-sm">{recipe.plateware}</div>
+                <div className="font-grotesk font-bold text-[#001b3c] mt-1 text-base">{recipe.plateware}</div>
               </div>
             )}
           </div>
@@ -88,7 +89,7 @@ export default async function RecipeDetailPage({
           {/* Ingredients */}
           {recipe.ingredients.length > 0 && (
             <section>
-              <h2 className="font-grotesk font-bold uppercase tracking-wide text-[#001b3c] text-lg border-l-4 border-[#526a8d] pl-4 mb-4">
+              <h2 className="font-grotesk font-bold uppercase tracking-wide text-[#001b3c] text-xl md:text-2xl border-l-4 border-[#526a8d] pl-4 mb-4">
                 Ingredients
               </h2>
               <div className="border-2 border-[#001b3c] bg-white divide-y divide-[#74777f]/30">
@@ -96,9 +97,9 @@ export default async function RecipeDetailPage({
                   const { qty, name } = parseIngredient(ing);
                   return (
                     <div key={i} className="py-3 flex justify-between items-center px-4">
-                      <span className="font-sans text-[#001b3c] text-base">{name}</span>
+                      <span className="font-sans text-[#001b3c] text-lg">{name}</span>
                       {qty && (
-                        <span className="font-grotesk font-bold text-xs bg-[#e7eeff] border border-[#74777f] px-2 py-1 ml-4 whitespace-nowrap flex-shrink-0">
+                        <span className="font-grotesk font-bold text-sm bg-[#e7eeff] border border-[#74777f] px-2 py-1 ml-4 whitespace-nowrap flex-shrink-0">
                           {qty}
                         </span>
                       )}
@@ -112,7 +113,7 @@ export default async function RecipeDetailPage({
           {/* Cook Steps */}
           {recipe.cook_steps.length > 0 && (
             <section>
-              <h2 className="font-grotesk font-bold uppercase tracking-wide text-[#001b3c] text-lg border-l-4 border-[#526a8d] pl-4 mb-4">
+              <h2 className="font-grotesk font-bold uppercase tracking-wide text-[#001b3c] text-xl md:text-2xl border-l-4 border-[#526a8d] pl-4 mb-4">
                 Cook Steps
               </h2>
               <div className="space-y-3">
@@ -127,7 +128,7 @@ export default async function RecipeDetailPage({
                     <span className="text-[#526a8d] font-grotesk font-black text-xl flex-shrink-0 leading-none mt-0.5">
                       {i + 1}.
                     </span>
-                    <p className="font-sans text-[#001b3c] text-base leading-relaxed">{step}</p>
+                    <p className="font-sans text-[#001b3c] text-lg leading-relaxed">{step}</p>
                   </div>
                 ))}
               </div>
@@ -137,7 +138,7 @@ export default async function RecipeDetailPage({
           {/* Plate Steps */}
           {recipe.plate_steps.length > 0 && (
             <section>
-              <h2 className="font-grotesk font-bold uppercase tracking-wide text-[#001b3c] text-lg border-l-4 border-[#526a8d] pl-4 mb-4">
+              <h2 className="font-grotesk font-bold uppercase tracking-wide text-[#001b3c] text-xl md:text-2xl border-l-4 border-[#526a8d] pl-4 mb-4">
                 Plating Steps
               </h2>
               <div className="space-y-3">
@@ -152,7 +153,7 @@ export default async function RecipeDetailPage({
                     <span className="text-[#526a8d] font-grotesk font-black text-xl flex-shrink-0 leading-none mt-0.5">
                       {i + 1}.
                     </span>
-                    <p className="font-sans text-[#001b3c] text-base leading-relaxed">{step}</p>
+                    <p className="font-sans text-[#001b3c] text-lg leading-relaxed">{step}</p>
                   </div>
                 ))}
               </div>
@@ -162,7 +163,7 @@ export default async function RecipeDetailPage({
           {/* Allergens */}
           {recipe.allergens && recipe.allergens.length > 0 && (
             <section>
-              <h2 className="font-grotesk font-bold uppercase tracking-wide text-[#001b3c] text-lg border-l-4 border-[#526a8d] pl-4 mb-4">
+              <h2 className="font-grotesk font-bold uppercase tracking-wide text-[#001b3c] text-xl md:text-2xl border-l-4 border-[#526a8d] pl-4 mb-4">
                 Allergens
               </h2>
               <div className="flex flex-wrap gap-2">
@@ -184,30 +185,7 @@ export default async function RecipeDetailPage({
       </main>
 
       {/* Bottom Nav */}
-      <nav className="bg-white border-t-2 border-[#001b3c] h-[80px] fixed bottom-0 w-full flex justify-around z-40">
-        {[
-          { label: 'Dashboard', icon: 'dashboard', href: '/dashboard' },
-          { label: 'Recipes', icon: 'restaurant_menu', href: '/dashboard', active: true },
-          { label: 'Quizzes', icon: 'quiz', href: '/quiz' },
-          { label: 'Settings', icon: 'settings', href: '/settings' },
-        ].map(tab => (
-          <Link
-            key={tab.label}
-            href={tab.href}
-            className={`flex flex-col items-center justify-center flex-1 h-full gap-1 transition-colors ${
-              tab.active ? 'bg-[#526a8d] text-white' : 'text-[#001b3c] hover:bg-[#f0f3ff]'
-            }`}
-          >
-            <span
-              className="material-symbols-outlined text-2xl"
-              style={tab.active ? { fontVariationSettings: "'FILL' 1" } : {}}
-            >
-              {tab.icon}
-            </span>
-            <span className="font-grotesk font-bold uppercase tracking-wider text-xs">{tab.label}</span>
-          </Link>
-        ))}
-      </nav>
+      <BottomNav activeTab="recipes" />
 
       {/* Chat FAB + Drawer (client) */}
       <RecipeActions recipeId={recipe.id} />

--- a/src/app/(linecook)/home/page.tsx
+++ b/src/app/(linecook)/home/page.tsx
@@ -1,0 +1,114 @@
+import Link from 'next/link';
+import { getRole } from '@/lib/get-role';
+import { BottomNav } from '@/components/BottomNav';
+import LogoutLink from '@/components/LogoutLink';
+
+export const dynamic = 'force-dynamic';
+
+export default async function HomePage() {
+  const role = (await getRole()) ?? 'linecook';
+  const isAdmin = role === 'admin';
+
+  return (
+    <div className="min-h-screen bg-[#f9f9ff]">
+      {/* Top App Bar */}
+      <header className="bg-white border-b-2 border-[#001b3c] h-[64px] fixed top-0 z-50 w-full flex items-center justify-between px-6">
+        <div className="flex items-center gap-3">
+          <span className="material-symbols-outlined text-[#001b3c]">dashboard</span>
+          <span className="font-grotesk font-black uppercase text-[#001b3c] text-xl tracking-tight">
+            PELLITO HUB
+          </span>
+        </div>
+        <span className="font-grotesk font-bold uppercase text-[#526a8d] text-sm">EN | ES</span>
+      </header>
+
+      <main className="pt-[64px] pb-[100px] px-6 max-w-6xl mx-auto">
+        <div className="py-6 border-b-2 border-[#001b3c] mb-6">
+          <h1 className="font-grotesk font-black uppercase text-[#001b3c] text-5xl md:text-6xl tracking-tight leading-none">
+            DASHBOARD
+          </h1>
+          <p className="text-[#43474e] mt-2 text-lg">
+            Signed in as <span className="font-grotesk font-bold uppercase tracking-wide">{role}</span>
+            <span className="mx-2 text-[#74777f]">·</span>
+            <LogoutLink />
+          </p>
+        </div>
+
+        {isAdmin ? (
+          <div className="grid grid-cols-1 md:grid-cols-2 gap-4">
+            <ExplainerCard
+              icon="restaurant_menu"
+              title="Manage recipes"
+              body="Create, edit, publish, and archive recipes. Bulk-import via CSV from the admin area."
+              href="/admin/recipes"
+              cta="Open admin"
+            />
+            <ExplainerCard
+              icon="quiz"
+              title="View quiz activity"
+              body="Review the log of quiz attempts across all users — see which recipes are being studied and how staff are scoring."
+              href="/quiz"
+              cta="View activity"
+            />
+          </div>
+        ) : (
+          <div className="grid grid-cols-1 md:grid-cols-3 gap-4">
+            <ExplainerCard
+              icon="restaurant_menu"
+              title="Browse recipes"
+              body="Filter by station — Saute, Grill, Fryer, Pantry, Pizza — and tap any card to see ingredients and cook steps."
+              href="/dashboard"
+              cta="View recipes"
+            />
+            <ExplainerCard
+              icon="quiz"
+              title="Take a quiz"
+              body="Open any recipe and scroll to the bottom. Tap the Quiz Yourself CTA to test your recall on ingredients and steps."
+              href="/dashboard"
+              cta="Pick a recipe"
+            />
+            <ExplainerCard
+              icon="forum"
+              title="Ask Pellito Deckhand"
+              body="The chat button on any recipe page lets you ask the kitchen agent for prep tips, allergen swaps, and more."
+              href="/dashboard"
+              cta="Open recipes"
+            />
+          </div>
+        )}
+      </main>
+
+      <BottomNav activeTab="dashboard" />
+    </div>
+  );
+}
+
+function ExplainerCard({
+  icon,
+  title,
+  body,
+  href,
+  cta,
+}: {
+  icon: string;
+  title: string;
+  body: string;
+  href: string;
+  cta: string;
+}) {
+  return (
+    <Link
+      href={href}
+      className="border-2 border-[#001b3c] bg-white p-6 flex flex-col gap-3 hover:bg-[#f0f3ff] transition-colors"
+    >
+      <span className="material-symbols-outlined text-[#526a8d] text-4xl">{icon}</span>
+      <h2 className="font-grotesk font-bold uppercase text-[#001b3c] text-xl tracking-tight">
+        {title}
+      </h2>
+      <p className="font-sans text-[#43474e] text-base leading-relaxed">{body}</p>
+      <span className="mt-auto pt-2 font-grotesk font-bold uppercase tracking-widest text-sm text-[#526a8d]">
+        {cta} →
+      </span>
+    </Link>
+  );
+}

--- a/src/app/(linecook)/quiz/page.tsx
+++ b/src/app/(linecook)/quiz/page.tsx
@@ -1,0 +1,131 @@
+import { desc, eq } from 'drizzle-orm';
+import { db } from '@/db';
+import { metrics, quizQuestions, recipes } from '@/db/schema';
+import { getRole } from '@/lib/get-role';
+import { BottomNav } from '@/components/BottomNav';
+
+export const dynamic = 'force-dynamic';
+
+export default async function QuizHistoryPage() {
+  const role = (await getRole()) ?? 'linecook';
+  const isAdmin = role === 'admin';
+
+  const limit = isAdmin ? 100 : 20;
+  const baseQuery = db
+    .select({
+      id: metrics.id,
+      correct: metrics.correct,
+      created_at: metrics.created_at,
+      role: metrics.role,
+      recipe_title: recipes.title,
+      question_text: quizQuestions.question_text,
+    })
+    .from(metrics)
+    .leftJoin(recipes, eq(metrics.recipe_id, recipes.id))
+    .leftJoin(quizQuestions, eq(metrics.question_id, quizQuestions.id))
+    .orderBy(desc(metrics.created_at))
+    .limit(limit);
+
+  const rows = isAdmin
+    ? await baseQuery
+    : await baseQuery.where(eq(metrics.role, role));
+
+  const totals = {
+    attempts: rows.length,
+    correct: rows.filter(r => r.correct).length,
+  };
+
+  return (
+    <div className="min-h-screen bg-[#f9f9ff]">
+      <header className="bg-white border-b-2 border-[#001b3c] h-[64px] fixed top-0 z-50 w-full flex items-center justify-between px-6">
+        <div className="flex items-center gap-3">
+          <span className="material-symbols-outlined text-[#001b3c]">quiz</span>
+          <span className="font-grotesk font-black uppercase text-[#001b3c] text-xl tracking-tight">
+            PELLITO HUB
+          </span>
+        </div>
+        <span className="font-grotesk font-bold uppercase text-[#526a8d] text-sm">EN | ES</span>
+      </header>
+
+      <main className="pt-[64px] pb-[100px] px-6 max-w-6xl mx-auto">
+        <div className="py-6 border-b-2 border-[#001b3c] mb-6">
+          <h1 className="font-grotesk font-black uppercase text-[#001b3c] text-5xl md:text-6xl tracking-tight leading-none">
+            {isAdmin ? 'QUIZ ACTIVITY' : 'YOUR QUIZZES'}
+          </h1>
+          <p className="text-[#43474e] mt-2 text-lg">
+            {isAdmin
+              ? 'Most recent 100 attempts across all roles.'
+              : 'Most recent 20 attempts on this account.'}
+          </p>
+        </div>
+
+        {rows.length === 0 ? (
+          <div className="border-2 border-[#001b3c] bg-white p-12 text-center">
+            <span className="material-symbols-outlined text-[#74777f] text-6xl block">quiz</span>
+            <p className="font-grotesk uppercase font-bold text-[#001b3c] mt-4 text-lg tracking-wide">
+              No quizzes taken yet
+            </p>
+            <p className="text-[#43474e] mt-2 text-base">
+              Open a recipe and tap the Quiz Yourself CTA at the bottom.
+            </p>
+          </div>
+        ) : (
+          <>
+            <div className="grid grid-cols-2 gap-3 mb-6">
+              <Stat label="Attempts" value={totals.attempts.toString()} />
+              <Stat
+                label="Correct"
+                value={`${totals.correct} / ${totals.attempts}`}
+              />
+            </div>
+
+            <div className="border-2 border-[#001b3c] bg-white divide-y divide-[#74777f]/30">
+              {rows.map(r => (
+                <div key={r.id} className="px-4 py-3 flex items-start gap-4">
+                  <span
+                    className={`material-symbols-outlined text-2xl flex-shrink-0 ${
+                      r.correct ? 'text-[#0a6c3d]' : 'text-[#ba1a1a]'
+                    }`}
+                  >
+                    {r.correct ? 'check_circle' : 'cancel'}
+                  </span>
+                  <div className="flex-1 min-w-0">
+                    <p className="font-grotesk font-bold uppercase text-[#001b3c] text-base tracking-tight truncate">
+                      {r.recipe_title ?? '(deleted recipe)'}
+                    </p>
+                    <p className="font-sans text-[#43474e] text-sm mt-0.5 line-clamp-2">
+                      {r.question_text ?? '(question removed)'}
+                    </p>
+                  </div>
+                  <div className="text-right flex-shrink-0">
+                    {isAdmin && (
+                      <p className="font-grotesk font-bold uppercase text-xs text-[#526a8d] tracking-wide">
+                        {r.role}
+                      </p>
+                    )}
+                    <p className="font-sans text-xs text-[#74777f] mt-0.5">
+                      {r.created_at ? new Date(r.created_at).toLocaleString() : ''}
+                    </p>
+                  </div>
+                </div>
+              ))}
+            </div>
+          </>
+        )}
+      </main>
+
+      <BottomNav activeTab="quizzes" />
+    </div>
+  );
+}
+
+function Stat({ label, value }: { label: string; value: string }) {
+  return (
+    <div className="border-2 border-[#001b3c] bg-white p-4">
+      <div className="font-grotesk font-bold uppercase tracking-wide text-xs text-[#74777f]">
+        {label}
+      </div>
+      <div className="font-grotesk font-black text-[#001b3c] text-2xl mt-1">{value}</div>
+    </div>
+  );
+}

--- a/src/app/(linecook)/settings/page.tsx
+++ b/src/app/(linecook)/settings/page.tsx
@@ -1,0 +1,121 @@
+import Link from 'next/link';
+import { getRole } from '@/lib/get-role';
+import { BottomNav } from '@/components/BottomNav';
+import LogoutLink from '@/components/LogoutLink';
+
+export const dynamic = 'force-dynamic';
+
+export default async function SettingsPage() {
+  const role = (await getRole()) ?? 'linecook';
+
+  return (
+    <div className="min-h-screen bg-[#f9f9ff]">
+      <header className="bg-white border-b-2 border-[#001b3c] h-[64px] fixed top-0 z-50 w-full flex items-center justify-between px-6">
+        <div className="flex items-center gap-3">
+          <span className="material-symbols-outlined text-[#001b3c]">settings</span>
+          <span className="font-grotesk font-black uppercase text-[#001b3c] text-xl tracking-tight">
+            PELLITO HUB
+          </span>
+        </div>
+        <span className="font-grotesk font-bold uppercase text-[#526a8d] text-sm">EN | ES</span>
+      </header>
+
+      <main className="pt-[64px] pb-[100px] px-6 max-w-2xl mx-auto">
+        <div className="py-6 border-b-2 border-[#001b3c] mb-6">
+          <h1 className="font-grotesk font-black uppercase text-[#001b3c] text-5xl md:text-6xl tracking-tight leading-none">
+            SETTINGS
+          </h1>
+        </div>
+
+        {/* Account */}
+        <section className="mb-8">
+          <h2 className="font-grotesk font-bold uppercase tracking-wide text-[#001b3c] text-xl border-l-4 border-[#526a8d] pl-4 mb-4">
+            Account
+          </h2>
+          <div className="border-2 border-[#001b3c] bg-white p-6 space-y-4">
+            <Row label="Signed in as" value={role} />
+            <div className="pt-4 border-t border-[#74777f]/30 flex flex-col sm:flex-row gap-3">
+              <LogoutLink variant="button" />
+              <Link
+                href="/login"
+                className="border-2 border-[#001b3c] bg-white px-6 py-3 font-grotesk font-bold uppercase tracking-widest text-base text-[#001b3c] hover:bg-[#f0f3ff] transition-colors text-center"
+              >
+                Switch user
+              </Link>
+            </div>
+            <p className="font-sans text-sm text-[#74777f]">
+              "Switch user" sends you to the login page without clearing the current session.
+              Use "Log out" to fully end the session before signing in as another role.
+            </p>
+          </div>
+        </section>
+
+        {/* Language */}
+        <section className="mb-8">
+          <h2 className="font-grotesk font-bold uppercase tracking-wide text-[#001b3c] text-xl border-l-4 border-[#526a8d] pl-4 mb-4">
+            Language
+          </h2>
+          <div className="border-2 border-[#001b3c] bg-white p-6">
+            {/* TODO: wire up i18n — toggle is display-only for now */}
+            <div className="flex gap-2">
+              <button
+                type="button"
+                className="px-6 py-3 font-grotesk font-bold uppercase tracking-[0.1em] text-base border-2 border-[#001b3c] bg-[#526a8d] text-white"
+              >
+                EN
+              </button>
+              <button
+                type="button"
+                disabled
+                className="px-6 py-3 font-grotesk font-bold uppercase tracking-[0.1em] text-base border-2 border-[#001b3c] bg-white text-[#001b3c] opacity-50 cursor-not-allowed"
+              >
+                ES
+              </button>
+            </div>
+            <p className="font-sans text-sm text-[#74777f] mt-3">
+              Spanish translations coming soon.
+            </p>
+          </div>
+        </section>
+
+        {role === 'admin' && (
+          <section>
+            <h2 className="font-grotesk font-bold uppercase tracking-wide text-[#001b3c] text-xl border-l-4 border-[#526a8d] pl-4 mb-4">
+              Admin
+            </h2>
+            <Link
+              href="/admin"
+              className="border-2 border-[#001b3c] bg-white px-6 py-5 flex items-center gap-4 hover:bg-[#f0f3ff] transition-colors"
+            >
+              <span className="material-symbols-outlined text-[#526a8d] text-3xl">build</span>
+              <div className="flex-1">
+                <p className="font-grotesk font-bold uppercase text-[#001b3c] text-lg tracking-tight">
+                  Manager dashboard
+                </p>
+                <p className="font-sans text-sm text-[#43474e] mt-0.5">
+                  Recipe CRUD, CSV import, and quiz generation.
+                </p>
+              </div>
+              <span className="material-symbols-outlined text-[#74777f]">arrow_forward</span>
+            </Link>
+          </section>
+        )}
+      </main>
+
+      <BottomNav activeTab="settings" />
+    </div>
+  );
+}
+
+function Row({ label, value }: { label: string; value: string }) {
+  return (
+    <div className="flex items-baseline justify-between gap-4">
+      <span className="font-grotesk font-bold uppercase tracking-wide text-sm text-[#74777f]">
+        {label}
+      </span>
+      <span className="font-grotesk font-bold uppercase text-[#001b3c] text-base tracking-tight">
+        {value}
+      </span>
+    </div>
+  );
+}

--- a/src/components/BottomNav.tsx
+++ b/src/components/BottomNav.tsx
@@ -1,0 +1,38 @@
+import Link from 'next/link';
+
+export type BottomNavTab = 'dashboard' | 'recipes' | 'quizzes' | 'settings';
+
+const TABS: { id: BottomNavTab; label: string; icon: string; href: string }[] = [
+  { id: 'dashboard', label: 'Dashboard', icon: 'dashboard', href: '/home' },
+  { id: 'recipes', label: 'Recipes', icon: 'restaurant_menu', href: '/dashboard' },
+  { id: 'quizzes', label: 'Quizzes', icon: 'quiz', href: '/quiz' },
+  { id: 'settings', label: 'Settings', icon: 'settings', href: '/settings' },
+];
+
+export function BottomNav({ activeTab }: { activeTab: BottomNavTab }) {
+  return (
+    <nav className="bg-white border-t-2 border-[#001b3c] h-[80px] fixed bottom-0 w-full flex justify-around z-40">
+      {TABS.map(tab => (
+        <Link
+          key={tab.id}
+          href={tab.href}
+          className={`flex flex-col items-center justify-center flex-1 h-full gap-1 transition-colors ${
+            tab.id === activeTab
+              ? 'bg-[#526a8d] text-white'
+              : 'text-[#001b3c] hover:bg-[#f0f3ff]'
+          }`}
+        >
+          <span
+            className="material-symbols-outlined text-2xl"
+            style={tab.id === activeTab ? { fontVariationSettings: "'FILL' 1" } : {}}
+          >
+            {tab.icon}
+          </span>
+          <span className="font-grotesk font-bold uppercase tracking-wider text-xs">
+            {tab.label}
+          </span>
+        </Link>
+      ))}
+    </nav>
+  );
+}

--- a/src/components/LogoutLink.tsx
+++ b/src/components/LogoutLink.tsx
@@ -1,0 +1,44 @@
+'use client';
+
+import { useRouter } from 'next/navigation';
+import { useState } from 'react';
+
+export default function LogoutLink({
+  variant = 'link',
+}: {
+  variant?: 'link' | 'button';
+}) {
+  const router = useRouter();
+  const [busy, setBusy] = useState(false);
+
+  async function handle() {
+    setBusy(true);
+    await fetch('/api/auth/logout', { method: 'POST' });
+    router.push('/login');
+    router.refresh();
+  }
+
+  if (variant === 'button') {
+    return (
+      <button
+        type="button"
+        onClick={handle}
+        disabled={busy}
+        className="border-2 border-[#001b3c] bg-white px-6 py-3 font-grotesk font-bold uppercase tracking-widest text-base text-[#001b3c] hover:bg-[#ba1a1a] hover:text-white hover:border-[#ba1a1a] transition-colors disabled:opacity-50"
+      >
+        {busy ? 'Logging out…' : 'Log out'}
+      </button>
+    );
+  }
+
+  return (
+    <button
+      type="button"
+      onClick={handle}
+      disabled={busy}
+      className="font-grotesk font-bold uppercase tracking-wide text-sm text-[#526a8d] hover:text-[#ba1a1a] underline disabled:opacity-50"
+    >
+      {busy ? 'Logging out…' : 'Log out'}
+    </button>
+  );
+}

--- a/src/lib/get-role.ts
+++ b/src/lib/get-role.ts
@@ -1,0 +1,9 @@
+import { cookies } from 'next/headers';
+import { verifySession, COOKIE_NAME } from '@/lib/session';
+
+export async function getRole(): Promise<'admin' | 'linecook' | null> {
+  const cookieStore = await cookies();
+  const value = cookieStore.get(COOKIE_NAME)?.value;
+  if (!value) return null;
+  return verifySession(value);
+}


### PR DESCRIPTION
…raphy bump

- New /home route: role-aware Dashboard explainer (linecook 3-card, admin 2-card)
- New /quiz route: quiz attempt history from metrics table (linecook last 20, admin last 100)
- New /settings route: account info, logout, language toggle stub, admin shortcut
- Shared BottomNav component; Dashboard tab now routes to /home instead of /dashboard
- LogoutLink component (link + button variants) using existing POST /api/auth/logout
- Typography: max-w-4xl to max-w-6xl, heading/card/ingredient/step text bumped across list and detail